### PR TITLE
bugfix using specific version of sqlite #staff

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 
 gem "rspec"
 gem "activerecord"
-gem "sqlite3"
+gem "sqlite3", "~> 1.3.6"
 gem "rake"
 gem "database_cleaner"
 gem "pry"


### PR DESCRIPTION
students are running in to trouble with this lab
https://learn.co/tracks/web-development-immersive-2-0-module-one/orms-and-active-record/activerecord/translating-from-orm-to-activerecord
turns out there's an open issue against active record / rails opened 3 days ago having to do with a new version of sqlite

https://github.com/rails/rails/issues/35153 (edited) 

people in that thread suggest a fix "You can specify `gem "sqlite3", "~> 1.3.6"` in your Gemfile explicitly OR wait the new rails version to be released OR use master directly."

This pull request adds sqlite 1.3.6 to Gemfile.